### PR TITLE
Remove calling of deprecated utils.ios.getter function

### DIFF
--- a/src/localize.ios.ts
+++ b/src/localize.ios.ts
@@ -8,7 +8,7 @@ const getBundle = (function () {
   let bundle = null;
   return function () {
     if (bundle === null) {
-      bundle = utils.ios.getter(NSBundle, NSBundle.mainBundle);
+      bundle = NSBundle.mainBundle;
     }
     return bundle;
   };


### PR DESCRIPTION
In NativeScript 5.4.0 utils.ios.getter function marked as deprecate.

I am not sure about the real reason for this, but correspondent pull-request could be checked here - NativeScript/NativeScript#7054.