### PR TITLE
fix: make plugin hooks compatible with CLI 6.0.0

### DIFF
--- a/src/typings/nativescript.d.ts
+++ b/src/typings/nativescript.d.ts
@@ -5,21 +5,18 @@ interface IAndroidResourcesMigrationService {
 }
 
 interface ILogger {
-  setLevel(level: string): void;
+  initialize(opts?: any): void;
+  initializeCliLogger(): void;
   getLevel(): string;
   fatal(formatStr?: any, ...args: any[]): void;
   error(formatStr?: any, ...args: any[]): void;
   warn(formatStr?: any, ...args: any[]): void;
-  warnWithLabel(formatStr?: any, ...args: any[]): void;
   info(formatStr?: any, ...args: any[]): void;
   debug(formatStr?: any, ...args: any[]): void;
   trace(formatStr?: any, ...args: any[]): void;
   printMarkdown(...args: any[]): void;
-  out(formatStr?: any, ...args: any[]): void;
-  write(...args: any[]): void;
   prepare(item: any): string;
-  printInfoMessageOnSameLine(message: string): void;
-  printMsgWithTimeout(message: string, timeout: number): Promise<void>;
+  isVerbose(): boolean;
 }
 
 interface IPlatformData {
@@ -27,11 +24,8 @@ interface IPlatformData {
   platformProjectService: IPlatformProjectService;
   projectRoot: string;
   normalizedPlatformName: string;
+  platformNameLowerCase: string;
   appDestinationDirectoryPath: string;
-  deviceBuildOutputPath: string;
-  emulatorBuildOutputPath?: string;
-  validPackageNamesForDevice: string[];
-  validPackageNamesForEmulator?: string[];
   frameworkFilesExtensions: string[];
   frameworkDirectoriesExtensions?: string[];
   frameworkDirectoriesNames?: string[];
@@ -72,4 +66,12 @@ interface IProjectData {
   getAppDirectoryRelativePath(): string;
   getAppResourcesDirectoryPath(projectDir?: string): string;
   getAppResourcesRelativeDirectoryPath(): string;
+}
+
+interface IPlatformsDataService {
+  getPlatformData(platform: string, projectData: IProjectData): IPlatformData;
+}
+
+interface IInjector {
+  resolve<T>(name: string, ctorArguments?: any): any;
 }


### PR DESCRIPTION
In CLI 6.0.0 the hooks args have been changed. Make the current plugin hooks compatible with both CLI 6.0.0 and 5.x.x.
Remove `platformsData` from args, as it has been renamed and it cannot be resolved anymore. Replace it with correct service.